### PR TITLE
fixes a broken link and uses correct gem name in gem install line in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This gem uses Faraday and Hashie to make requests and parse the responses.
 
 ## Usage
 
-Obtain an access token from Pinterest. You can generate one [here](https://developers.pinterest.com/docs/api/access_token/).
+Obtain an access token from Pinterest. You can generate one [here](https://developers.pinterest.com/tools/access_token/).
 
-$ gem install pinterest
+$ gem install pinterest-api
 
 ```ruby
 require 'pinterest-api'


### PR DESCRIPTION
I'm assuming the bash line to install this gem is `gem install pinterest-api`, rather than `gem install pinterest`, right? 

Also fixes a broken link to the Pinterest page for generating tokens. 