### PR TITLE
pass request options to faraday -- for timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /tmp/
 .env
 *.gem
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ client.follow_board(<board_id>)
 client.unfollow_board(<board_id>)
 
 # Follow an interest
+> This endpoint is no longer part of the Pinterest documentation, and has always returned an error
 client.follow_interest(<interest_id>)
 
 # Unfollow an interest
+> This endpoint is no longer part of the Pinterest documentation, and has always returned an error
 client.unfollow_interest(<interest_id>)
 
 # Get all of authenticated users's pins

--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ OAuth values from Pinterest in ```request.env['omniauth.auth']```
 For more details, check out "Integrating OmniAuth Into Your Application"  
 https://github.com/intridea/omniauth
 
+## Request options
+
+You can set any request options that are valid in `Faraday::Connection` by adding them as a has to the Pinterest Client initializer.
+
+Example:
+
+```
+  client = Pinterest::Client.new(ACCESS_TOKEN, {
+    request: {
+      timeout: 1.5,
+      open_timeout: 1,
+    }
+  })
+
+  counts = client.get_user('<username>', {fields: "counts"})
+```
+
 ## Known Issues
 
 The gem is currently under active development. The following issues cause the test specs to fail, though it's not clear to me that these issues are not with the Pinterest API itself.  

--- a/lib/pinterest/client.rb
+++ b/lib/pinterest/client.rb
@@ -14,8 +14,9 @@ module Pinterest
     DEFAULT_USER_AGENT = "Pinterest Ruby Gem #{Pinterest::VERSION}".freeze
     DEFAULT_ADAPTER = Faraday.default_adapter
 
-    def initialize(access_token = nil)
+    def initialize(access_token = nil, connection_options={})
       @access_token = access_token
+      @connection_options = connection_options
     end
 
     attr_reader :access_token
@@ -61,10 +62,10 @@ module Pinterest
     end
 
     def connection(raw = false, log = false)
-      options = {
+      options = @connection_options.merge({
         :headers => {'Accept' => "application/json; charset=utf-8", 'User-Agent' => user_agent},
         :url => endpoint,
-      }
+      })
 
       Faraday::Connection.new(options) do |connection|
         unless raw

--- a/lib/pinterest/client.rb
+++ b/lib/pinterest/client.rb
@@ -52,6 +52,10 @@ module Pinterest
         when :get
           path = path + "?access_token=" + @access_token
           request.url(URI.encode(path), options)
+        when :patch
+          request.path = path + "?access_token=" + @access_token
+          request.body = options unless options.empty?
+          request.headers['Authorization'] = "BEARER #{@access_token}"
         when :post, :put, :delete
           request.path = URI.encode(path)
           request.body = options unless options.empty?

--- a/lib/pinterest/client/pin.rb
+++ b/lib/pinterest/client/pin.rb
@@ -14,8 +14,8 @@ module Pinterest
         post('pins', params)
       end
 
-      def update_pin(params={})
-        patch('pins', params)
+      def update_pin(id, params={})
+        patch("pins/#{id}", params)
       end
 
       def delete_pin(id)

--- a/lib/pinterest/version.rb
+++ b/lib/pinterest/version.rb
@@ -1,3 +1,3 @@
 module Pinterest
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/pinterest.gemspec
+++ b/pinterest.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "vcr", "~> 2.9"
   spec.add_development_dependency "dotenv", "~> 2.0"
-  spec.add_development_dependency "webmock", "~> 1.0"
+  spec.add_development_dependency "webmock", "~> 3.0.1"
 
   spec.add_dependency 'faraday', "~> 0.9"
   spec.add_dependency 'faraday_middleware', "~> 0.9"

--- a/spec/client/pin_spec.rb
+++ b/spec/client/pin_spec.rb
@@ -56,22 +56,22 @@ describe "Pinterest::Client::Pin" do
     context "have the parameters for a pin" do
       it "should update a pin" do
         VCR.use_cassette("v1_update_pin") do
-          response = @client.update_pin({
-            id: '154177987221106968',
+          response = @client.update_pin('333547916137432730', {
+            pin: '333547916137432730',
             note: "Test from Ruby gem at #{Time.now.to_s}"
           })
-          expect(response.data.id).to be
+          expect(response.data.id).to eq('333547916137432730')
         end
       end
     end
     context "missing image for a pin" do
       it "should response with an error message" do
         VCR.use_cassette("v1_not_update_pin") do
-          response = @client.update_pin({
-            id: '123',
+          response = @client.update_pin('123', {
+            pin: '123',
             note: "Test from Ruby gem at #{Time.now.to_s}"
           })
-          expect(response.message).to be
+          expect(response.message).to eq('Pin not found.')
         end
       end
     end
@@ -101,7 +101,7 @@ describe "Pinterest::Client::Pin" do
     it "should get the board's pins" do
       VCR.use_cassette("v1_boards_pins") do
         response = @client.get_board_pins('154178055932402553')
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end

--- a/spec/client/user_spec.rb
+++ b/spec/client/user_spec.rb
@@ -33,7 +33,7 @@ describe "Pinterest::Client::User" do
     it "should get the user's likes" do
       VCR.use_cassette("v1_me_likes") do
         response = @client.get_likes
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
         expect(response.data.first.keys).to match_array(['id', 'link', 'note', 'url'])
       end
     end
@@ -54,7 +54,7 @@ describe "Pinterest::Client::User" do
     it "should search the user's pins" do
       VCR.use_cassette("v1_me_get_pins") do
         response = @client.get_pins(query: 'shopseen')
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end
@@ -63,7 +63,7 @@ describe "Pinterest::Client::User" do
     it "should search the user's boards" do
       VCR.use_cassette("v1_me_get_boards") do
         response = @client.get_boards(query: 'randumb')
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end
@@ -72,7 +72,7 @@ describe "Pinterest::Client::User" do
     it "should get the user's followers" do
       VCR.use_cassette("v1_me_followers") do
         response = @client.get_followers
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end
@@ -81,7 +81,7 @@ describe "Pinterest::Client::User" do
     it "should get boards the user is following" do
       VCR.use_cassette("v1_me_following_boards") do
         response = @client.get_followed_boards
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end
@@ -90,7 +90,7 @@ describe "Pinterest::Client::User" do
     it "should get users the user is following" do
       VCR.use_cassette("v1_me_following_users") do
         response = @client.get_followed_users
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end
@@ -99,7 +99,7 @@ describe "Pinterest::Client::User" do
     it "should get interests the user is following" do
       VCR.use_cassette("v1_me_following_interests") do
         response = @client.get_followed_interests
-        expect(response.data.class).to eq(Array)
+        expect(response.data.class).to eq(Hashie::Array)
       end
     end
   end
@@ -186,9 +186,9 @@ describe "Pinterest::Client::User" do
 
   describe 'POST /v1/me/following/interests' do
     context "another interest exists" do
-      it "should follow the interest" do
+      it "should follow the interest", skip: "Follow interests API is not supported" do
         VCR.use_cassette("v1_me_follow_existing_interest") do
-          response = @client.follow_interest('901179409185')
+          response = @client.follow_interest('937523231401')
           expect(response).to have_key(:data)
           expect(response.data).to be_falsey
         end
@@ -206,7 +206,7 @@ describe "Pinterest::Client::User" do
 
   describe 'DELETE /v1/me/following/interests/<interest_id>/' do
     context "another interest exists" do
-      it "should unfollow the interest" do
+      it "should unfollow the interest", skip: "Unfollow interests API is not supported" do
         VCR.use_cassette("v1_me_unfollow_existing_interest") do
           response = @client.unfollow_interest('901179409185')
           p response.inspect

--- a/spec/fixtures/cassettes/v1_me_get_boards.yml
+++ b/spec/fixtures/cassettes/v1_me_get_boards.yml
@@ -1,26 +1,22 @@
 ---
 http_interactions:
 - request:
-    method: patch
-    uri: https://api.pinterest.com/v1/pins/123/
+    method: get
+    uri: https://api.pinterest.com/v1/me/search/boards/?access_token=<HIDDEN>&query=randumb
     body:
-      encoding: UTF-8
-      string: note=Test+from+Ruby+gem+at+2017-05-23+00%3A20%3A00+-0400&pin=123
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8
       User-Agent:
       - Pinterest Ruby Gem 0.2.2
-      Authorization:
-      - BEARER <HIDDEN>
-      Content-Type:
-      - application/x-www-form-urlencoded
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 404
-      message: NOT FOUND
+      code: 200
+      message: OK
     headers:
       Access-Control-Allow-Origin:
       - "*"
@@ -35,22 +31,22 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Pinterest-Rid:
-      - '470209956845'
+      - '200579171037'
       X-Ratelimit-Limit:
       - '1000'
       X-Ratelimit-Remaining:
-      - '986'
+      - '891'
       Content-Length:
-      - '44'
+      - '52'
       Date:
-      - Tue, 23 May 2017 04:20:00 GMT
+      - Tue, 23 May 2017 03:00:50 GMT
       Connection:
       - keep-alive
       Pinterest-Generated-By:
-      - devplatform-devapi-prod-0a012b44
+      - devplatform-devapi-prod-0a01ad2e
     body:
       encoding: UTF-8
-      string: '{"message": "Pin not found.", "type": "api"}'
+      string: '{"data": [], "page": {"cursor": null, "next": null}}'
     http_version: 
-  recorded_at: Tue, 23 May 2017 04:20:00 GMT
+  recorded_at: Tue, 23 May 2017 03:00:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/v1_me_get_pins.yml
+++ b/spec/fixtures/cassettes/v1_me_get_pins.yml
@@ -1,26 +1,22 @@
 ---
 http_interactions:
 - request:
-    method: patch
-    uri: https://api.pinterest.com/v1/pins/123/
+    method: get
+    uri: https://api.pinterest.com/v1/me/search/pins/?access_token=<HIDDEN>&query=shopseen
     body:
-      encoding: UTF-8
-      string: note=Test+from+Ruby+gem+at+2017-05-23+00%3A20%3A00+-0400&pin=123
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8
       User-Agent:
       - Pinterest Ruby Gem 0.2.2
-      Authorization:
-      - BEARER <HIDDEN>
-      Content-Type:
-      - application/x-www-form-urlencoded
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 404
-      message: NOT FOUND
+      code: 200
+      message: OK
     headers:
       Access-Control-Allow-Origin:
       - "*"
@@ -35,22 +31,22 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Pinterest-Rid:
-      - '470209956845'
+      - '178874558164'
       X-Ratelimit-Limit:
       - '1000'
       X-Ratelimit-Remaining:
-      - '986'
+      - '892'
       Content-Length:
-      - '44'
+      - '52'
       Date:
-      - Tue, 23 May 2017 04:20:00 GMT
+      - Tue, 23 May 2017 03:00:50 GMT
       Connection:
       - keep-alive
       Pinterest-Generated-By:
-      - devplatform-devapi-prod-0a012b44
+      - devplatform-devapi-prod-0a01ee84
     body:
       encoding: UTF-8
-      string: '{"message": "Pin not found.", "type": "api"}'
+      string: '{"data": [], "page": {"cursor": null, "next": null}}'
     http_version: 
-  recorded_at: Tue, 23 May 2017 04:20:00 GMT
+  recorded_at: Tue, 23 May 2017 03:00:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/v1_update_pin.yml
+++ b/spec/fixtures/cassettes/v1_update_pin.yml
@@ -2,53 +2,57 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://api.pinterest.com/v1/
+    uri: https://api.pinterest.com/v1/pins/333547916137432730/
     body:
       encoding: UTF-8
-      string: ''
+      string: note=Test+from+Ruby+gem+at+2017-05-23+00%3A20%3A00+-0400&pin=333547916137432730
     headers:
       Accept:
       - application/json; charset=utf-8
       User-Agent:
-      - Pinterest Ruby Gem 0.0.1
-      Content-Length:
-      - '0'
+      - Pinterest Ruby Gem 0.2.2
+      Authorization:
+      - BEARER <HIDDEN>
+      Content-Type:
+      - application/x-www-form-urlencoded
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 404
-      message: NOT FOUND
+      code: 200
+      message: OK
     headers:
-      Accept-Ranges:
-      - bytes
+      Access-Control-Allow-Origin:
+      - "*"
       Age:
       - '0'
       Cache-Control:
       - private
       Content-Type:
       - application/json
-      Date:
-      - Fri, 02 Oct 2015 04:00:18 GMT
-      Server:
-      - nginx
-      Via:
-      - 1.1 varnish
+      Pinterest-Version:
+      - c0f3f7d
+      X-Content-Type-Options:
+      - nosniff
       X-Pinterest-Rid:
-      - '663068971330'
-      X-Varnish:
-      - '63892550'
+      - '816611333499'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '987'
       Content-Length:
-      - '51'
+      - '304'
+      Date:
+      - Tue, 23 May 2017 04:20:00 GMT
       Connection:
       - keep-alive
+      Pinterest-Generated-By:
+      - devplatform-devapi-prod-0a012f8f
     body:
       encoding: UTF-8
-      string: |-
-        {
-          "message": "404: Not Found",
-          "type": "http"
-        }
+      string: '{"data": {"url": "https://www.pinterest.com/pin/333547916137432730/",
+        "note": "Test from Ruby gem at 2017-05-23 00:20:00 -0400", "link": "https://www.pinterest.com/r/pin/333547916137432730/4779055074072594921/97052ead3fee1fdc3b8402ad515e68456cba554610086cb57f700b137867762b",
+        "id": "333547916137432730"}}'
     http_version: 
-  recorded_at: Fri, 02 Oct 2015 04:00:18 GMT
+  recorded_at: Tue, 23 May 2017 04:20:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/pinterest_spec.rb
+++ b/spec/pinterest_spec.rb
@@ -6,13 +6,23 @@ describe Pinterest do
   end
 
   describe Pinterest::Client do
-
     let(:client){Pinterest::Client.new(ENV['ACCESS_TOKEN'])}
 
     it 'should exist' do
       expect(client).to be_kind_of(Pinterest::Client)
     end
 
+    it 'should be able to set connection request options' do
+      timeout_client = Pinterest::Client.new(ENV['ACCESS_TOKEN'], {
+        request: {
+          timeout: 0.0001,
+          open_timeout: 5,
+        }
+      })
+      conn = timeout_client.send(:connection)
+      expect(conn.options).to be_a Faraday::RequestOptions
+      expect(conn.options.timeout).to be(0.0001)
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'webmock/rspec'
 require 'dotenv'
 
 Dotenv.load
+ENV['ACCESS_TOKEN'] ||= "test"
 
 RSpec.configure do |config|
   # some (optional) config here


### PR DESCRIPTION
This PR adds the ability to pass any valid `Faraday::Connection` options to the client initializer.
Example usage:
```
client = Pinterest::Client.new(ACCESS_TOKEN, {
  request: {
    timeout: 1.5,
    open_timeout: 1,
  }
})
```

This PR also updates the pin patch endpoint to pass an id in the path and an access token in the query (based on pinterest docs)