### PR TITLE
Allow for customizing Faraday middleware

### DIFF
--- a/lib/pinterest/client.rb
+++ b/lib/pinterest/client.rb
@@ -14,9 +14,10 @@ module Pinterest
     DEFAULT_USER_AGENT = "Pinterest Ruby Gem #{Pinterest::VERSION}".freeze
     DEFAULT_ADAPTER = Faraday.default_adapter
 
-    def initialize(access_token = nil, connection_options={})
+    def initialize(access_token = nil, connection_options={}, &connection_config)
       @access_token = access_token
       @connection_options = connection_options
+      @connection_config = connection_config
     end
 
     attr_reader :access_token
@@ -72,14 +73,18 @@ module Pinterest
       })
 
       Faraday::Connection.new(options) do |connection|
-        unless raw
-          connection.use FaradayMiddleware::Mashify
+        if @connection_config
+          @connection_config.call(connection)
+        else
+          unless raw
+            connection.use FaradayMiddleware::Mashify
+          end
+          connection.use Faraday::Request::Multipart
+          connection.use Faraday::Response::ParseJson
+          connection.use Faraday::Request::UrlEncoded
+          connection.response :logger if log
+          connection.adapter(adapter)
         end
-        connection.use Faraday::Request::Multipart
-        connection.use Faraday::Response::ParseJson
-        connection.use Faraday::Request::UrlEncoded
-        connection.response :logger if log
-        connection.adapter(adapter)
       end
     end
 

--- a/pinterest.gemspec
+++ b/pinterest.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "vcr", "~> 2.9"


### PR DESCRIPTION
I had a need for accessing response attributes such as the HTTP status and rate limit headers via Faraday middleware. This allows one to do just that and solves issues like https://github.com/realadeel/pinterest-api/issues/8. 